### PR TITLE
Fix tic-tac-toe second player move bug

### DIFF
--- a/frontend/src/components/Game.js
+++ b/frontend/src/components/Game.js
@@ -168,9 +168,9 @@ const Game = () => {
       // Set moving state to prevent double-clicks
       setIsMoving(true);
       
-      // Determine player symbol based on player index in room
-      const currentPlayer = room?.players?.find(p => p.user.id === user.id);
-      const playerIndex = room?.players?.findIndex(p => p.user.id === user.id);
+      // Determine player symbol based on active player index in room
+      const activePlayers = room?.players?.filter(p => !p.isSpectator) || [];
+      const playerIndex = activePlayers.findIndex(p => p.user.id === user.id);
       const symbol = playerIndex === 0 ? 'X' : 'O';
       
       // Optimistic UI update - immediately update the board


### PR DESCRIPTION
Fixes tic-tac-toe turn management by correctly filtering active players, resolving the glitch where the second user couldn't make moves.

The previous turn switching and symbol assignment logic incorrectly included spectators in player calculations, leading to an incorrect `playerIndex` and `currentTurn`, which caused the game to get stuck for the second player. This PR ensures only active players are considered for core game logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-c9d61bc0-afa1-4257-8f28-124b137585df">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c9d61bc0-afa1-4257-8f28-124b137585df">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

