### PR TITLE
Debug concurrent game user display issue

### DIFF
--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -18,7 +18,7 @@ export const AuthProvider = ({ children }) => {
 
   // Set up axios defaults and interceptors
   useEffect(() => {
-    const token = localStorage.getItem('token');
+    const token = sessionStorage.getItem('token');
     if (token) {
       axios.defaults.headers.common['Authorization'] = `Bearer ${token}`;
     }
@@ -29,7 +29,7 @@ export const AuthProvider = ({ children }) => {
       (error) => {
         if (error.response?.status === 401) {
           // Clear invalid token automatically
-          localStorage.removeItem('token');
+          sessionStorage.removeItem('token');
           delete axios.defaults.headers.common['Authorization'];
           setUser(null);
         }
@@ -45,7 +45,7 @@ export const AuthProvider = ({ children }) => {
   // Check if user is logged in on mount
   useEffect(() => {
     const checkAuth = async () => {
-      const token = localStorage.getItem('token');
+      const token = sessionStorage.getItem('token');
       if (token) {
         try {
           const response = await axios.get('/api/auth/profile');
@@ -58,7 +58,7 @@ export const AuthProvider = ({ children }) => {
           }
         } catch (error) {
           // Clear invalid token automatically
-          localStorage.removeItem('token');
+          sessionStorage.removeItem('token');
           delete axios.defaults.headers.common['Authorization'];
           setUser(null);
         }
@@ -75,7 +75,7 @@ export const AuthProvider = ({ children }) => {
       const response = await axios.post('/api/auth/login', { email, password });
       const { token, user } = response.data;
       
-      localStorage.setItem('token', token);
+      sessionStorage.setItem('token', token);
       axios.defaults.headers.common['Authorization'] = `Bearer ${token}`;
       setUser(user);
       return { success: true };
@@ -91,7 +91,7 @@ export const AuthProvider = ({ children }) => {
       const response = await axios.post('/api/auth/register', { username, email, password });
       const { token, user } = response.data;
       
-      localStorage.setItem('token', token);
+      sessionStorage.setItem('token', token);
       axios.defaults.headers.common['Authorization'] = `Bearer ${token}`;
       setUser(user);
       return { success: true };
@@ -105,7 +105,7 @@ export const AuthProvider = ({ children }) => {
     // Clean up user's room before logout
     const cleanupUserRoom = async () => {
       try {
-        const token = localStorage.getItem('token');
+        const token = sessionStorage.getItem('token');
         if (token) {
           // Leave current room if any
           await axios.post('/api/rooms/leave');
@@ -117,14 +117,14 @@ export const AuthProvider = ({ children }) => {
 
     cleanupUserRoom();
     
-    localStorage.removeItem('token');
+    sessionStorage.removeItem('token');
     delete axios.defaults.headers.common['Authorization'];
     setUser(null);
     setError('');
   };
 
   const clearAuth = () => {
-    localStorage.removeItem('token');
+    sessionStorage.removeItem('token');
     delete axios.defaults.headers.common['Authorization'];
     setUser(null);
   };

--- a/frontend/src/contexts/SocketContext.js
+++ b/frontend/src/contexts/SocketContext.js
@@ -20,7 +20,7 @@ export const SocketProvider = ({ children }) => {
 
   useEffect(() => {
     if (user && !socketRef.current) {
-      const token = localStorage.getItem('token');
+      const token = sessionStorage.getItem('token');
       const newSocket = io('http://localhost:5000', {
         auth: { token },
         reconnection: true,


### PR DESCRIPTION
Migrate authentication token storage from `localStorage` to `sessionStorage` to enable per-tab user sessions.

The original implementation used `localStorage` for storing authentication tokens, which is shared across all browser tabs. This caused a bug where logging in with different accounts in separate tabs would overwrite the token, leading to all tabs sharing the same user session. Switching to `sessionStorage` isolates the token per tab, allowing each tab to maintain its own distinct authentication state.

---
<a href="https://cursor.com/background-agent?bcId=bc-e63467ed-a521-4cf6-973f-acb8d2a466ce">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e63467ed-a521-4cf6-973f-acb8d2a466ce">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

